### PR TITLE
Add context.Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ import (
 )
 
 func main() {
-  ctls, err := youtube.Do("TOKEN", "oS169nq8Prw", 250)
+  ctx := context.Background()
+  ctls, err := youtube.Do(ctx, "TOKEN", "oS169nq8Prw", 250)
   if err != nil {
     log.Fatal(err)
   }
@@ -33,6 +34,10 @@ func main() {
   log.Printf("got %d comments", ctls.Len())
 }
 ```
+
+## Credentials
+
+You will need a YouTube API token, see the [docs](https://developers.google.com/youtube/v3/docs/).
 
 ## Options
 
@@ -43,14 +48,26 @@ The following `opt` overrides the default API endpoint used:
 
 ```golang
 func main() {
+  ctx := context.Background()
   e := "https://example.com"
-  _, err := youtube.Do("TOKEN", "oS169nq8Prw", 250, youtube.WithCustomEndpoint(e))
+  _, err := youtube.Do(ctx, "TOKEN", "oS169nq8Prw", 250, youtube.WithCustomEndpoint(e))
 }
 ```
 
-## Credentials
+## Context
 
-You will need a YouTube API token, see the [docs](https://developers.google.com/youtube/v3/docs/).
+`youtube.Do()` takes a `context.Context`, which allows you to cancel the request, or specify a
+sensible timeout etc.
+
+```golang
+func main() {
+  ctx := context.Background()
+  ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+  _, err := youtube.Do(ctx, "TOKEN", "oS169nq8Prw", 250)
+}
+```
 
 ## Other
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ sensible timeout etc.
 func main() {
   ctx := context.Background()
   ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
+  defer cancel()
 
   _, err := youtube.Do(ctx, "TOKEN", "oS169nq8Prw", 250)
 }

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The example below fetches a maxium of 250 comments for this
 package main
 
 import (
+  "context"
   "log"
 
   youtube "github.com/revett/youtube-comments/pkg"

--- a/pkg/request_test.go
+++ b/pkg/request_test.go
@@ -1,6 +1,7 @@
 package pkg_test
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -8,6 +9,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
+	"time"
 
 	youtube "github.com/revett/youtube-comments/pkg"
 	"github.com/stretchr/testify/require"
@@ -34,7 +36,11 @@ func TestDo(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	ctls, err := youtube.Do(token, videoID, maxComments, youtube.WithCustomEndpoint(srv.URL))
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+
+	ctls, err := youtube.Do(ctx, token, videoID, maxComments, youtube.WithCustomEndpoint(srv.URL))
 
 	require.NoError(t, err)
 	require.Len(t, ctls, 3)


### PR DESCRIPTION
### Problem

Following best practice, this should include `context.Context`

### Solution

Add it, with examples

### Notes

- None
